### PR TITLE
Require dspline >= 1.0.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,7 @@ License: MIT + file LICENSE
 Imports: 
     checkmate,
     cli,
-    dspline,
+    dspline (>= 1.0.1),
     ggplot2,
     Rcpp (>= 1.0.10),
     rlang,


### PR DESCRIPTION
The way `trendfilter` called `dspline_interp` seemed to need the fix in dspline 1.0.1, at least the way we used it in some epiprocess tests (https://github.com/cmu-delphi/epiprocess/pull/595#discussion_r1934757958).